### PR TITLE
Return 0 rather than 1 when LEVEL<LS_LEVEL

### DIFF
--- a/log.sh
+++ b/log.sh
@@ -66,7 +66,7 @@ _LS_FIND_LEVEL_STR () {
 LSLOG () {
   local LEVEL=$1
   shift
-  (( LEVEL < LS_LEVEL )) && return 1
+  (( LEVEL < LS_LEVEL )) && return 0
   local TS=$(date +'%Y-%m-%d %H:%M:%S.%N')
   # Keep digits only up to milliseconds
   TS=${TS%??????}


### PR DESCRIPTION
When logging at a level lower than LS_LEVEL, exit code is 1. This causes bash scripts with `set -e` to fail silently. Propose changing this to return 0 rather than 1 when LEVEL < LS_LEVEL.

Example to reproduce:
```
#!/bin/bash -e

export LS_LEVEL=20
source log.sh
LSDEBUG "foobar"
echo $? # Would print 1
echo "Not printing this. Quitely exited"
```
